### PR TITLE
Missing command-line option in example command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ $ sinfo		# returns cluster information
 
 Once you have your worker nodes Setup, you can also check the cluster is correctly Setup by running:
 ```
-$ srun hostname
+$ srun -N <NUMBER-OF-NODES> hostname
 ```
 Where `<NUMBER-OF-NODES>` is the number of worker nodes that are currently Setup. If you followed all of the steps correctly, this should return the name of all of your nodes.
 


### PR DESCRIPTION
There appears to be a missing command line option, inferred by the following paragraph that references `<NUMBER-OF-NODES>`. I've updated the srun invocation to use the missing value to run hostname on all configured nodes.